### PR TITLE
Update documentation

### DIFF
--- a/docs/reference/ImageGrab.rst
+++ b/docs/reference/ImageGrab.rst
@@ -15,8 +15,9 @@ or the clipboard to a PIL image memory.
     returned as an "RGBA" on macOS, or an "RGB" image otherwise.
     If the bounding box is omitted, the entire screen is copied.
 
-    On Linux, if ``xdisplay`` is ``None`` then ``gnome-screenshot`` will be used if it
-    is installed. To capture the default X11 display instead, pass ``xdisplay=""``.
+    On Linux, if ``xdisplay`` is ``None`` then ``gnome-screenshot`` or ``scrot`` will
+    be used if they are installed. To capture the default X11 display instead, pass
+    ``xdisplay=""``.
 
     .. versionadded:: 1.1.3 (Windows), 3.0.0 (macOS), 7.1.0 (Linux)
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7100, according ``scrot`` to the documentation. This would become part of https://pillow.readthedocs.io/en/stable/reference/ImageGrab.html